### PR TITLE
[BE] HOTFIX: 토큰 없이 API 요청 시 500 에러 발생 (DEV to MAIN)

### DIFF
--- a/backend/src/main/java/org/johoeunsae/exchangediary/auth/oauth2/filter/UserSessionAuthenticationFilter.java
+++ b/backend/src/main/java/org/johoeunsae/exchangediary/auth/oauth2/filter/UserSessionAuthenticationFilter.java
@@ -12,7 +12,6 @@ import org.johoeunsae.exchangediary.auth.jwt.excpetion.JwtAuthenticationTokenExc
 import org.johoeunsae.exchangediary.auth.oauth2.domain.UserSessionAuthenticationToken;
 import org.johoeunsae.exchangediary.auth.oauth2.domain.UserSessionDto;
 import org.johoeunsae.exchangediary.member.domain.MemberRole;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.Transient;
 import org.springframework.security.core.context.SecurityContext;
@@ -29,8 +28,6 @@ public class UserSessionAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request,
 			HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {
-		log.info("request Referer: " + request.getHeader(HttpHeaders.REFERER));
-
 		SecurityContext context = SecurityContextHolder.getContext();
 		Authentication authentication = context.getAuthentication();
 		if (authentication == null) {

--- a/backend/src/main/java/org/johoeunsae/exchangediary/exception/ExceptionController.java
+++ b/backend/src/main/java/org/johoeunsae/exchangediary/exception/ExceptionController.java
@@ -63,7 +63,7 @@ public class ExceptionController {
 		errors.put("errorReason", e.getMessage());
 		errors.put("timestamp", LocalDateTime.now());
 		return ResponseEntity
-				.status(HttpStatus.FORBIDDEN)
+				.status(HttpStatus.UNAUTHORIZED)
 				.body(errors);
 	}
 

--- a/backend/src/main/java/org/johoeunsae/exchangediary/exception/ExceptionController.java
+++ b/backend/src/main/java/org/johoeunsae/exchangediary/exception/ExceptionController.java
@@ -14,6 +14,7 @@ import org.johoeunsae.exchangediary.exception.status.ValidationExceptionStatusRe
 import org.johoeunsae.exchangediary.exception.utils.DiscordWebhookErrorHandler;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class ExceptionController {
+
 	private final ValidationExceptionStatusResolver validationExceptionStatusResolver;
 	private final DiscordWebhookErrorHandler discordWebhookErrorHandler;
 
@@ -51,6 +53,18 @@ public class ExceptionController {
 		return ResponseEntity
 				.status(e.getErrorReason().getStatusCode())
 				.body(e.getErrorReason());
+	}
+
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<?> handleAccessDeniedException(AccessDeniedException e) {
+		e.printStackTrace();
+		Map<String, Object> errors = new HashMap<>();
+		errors.put("success", false);
+		errors.put("errorReason", e.getMessage());
+		errors.put("timestamp", LocalDateTime.now());
+		return ResponseEntity
+				.status(HttpStatus.FORBIDDEN)
+				.body(errors);
 	}
 
 	@ExceptionHandler({


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../exchange-diary/issues/738


**TLDR;**
- 토큰 없이  `@PreAuthorize` 붙은 API 요청을 보내면 유저 인증 필터를 그대로 통과하고, 예외 처리가 없어서 그대로 500으로 날라감.
- `@PreAuthorize` 에 실패하면 발생하는 예외 핸들링 코드 추가해서 401로 가게 수정함.

**문제 발생 상황**
Swagger와 Actuator 엔드포인트에 대한 접근을 인증 없이 허용하기 위해서 `UserSessionAuthenticationFilter`에서 시큐리티 컨텍스트의 인증 정보(authentication)가 null일 경우, 필터를 통과시키도록 구현했었습니다. 
그런데 이 때문에 `@PreAuthorize` 어노테이션이 붙은 API로 요청이 오는 경우에도, 인증 정보가 없다면 이 필터를 통과해 버리게 되어, 시큐리티에서 `AccessDeniedException` 예외를 던졌고, 이 예외를 핸들링하는 부분이 없었습니다. 때문에 이 예외는 `@ExceptionHandler(Exception.class)`에 의해 잡히고, `@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)`에 의해 500 에러로 변환되어 클라이언트에게 전달되었습니다. (디코 알림도 이때 발생)

**문제 원인**
문제의 핵심은 인증 정보가 없는 상태에서도 특정 엔드포인트에 대한 접근이 허용되면서 발생한 예외가 적절히 처리되지 않았다는 것입니다. 초기의 접근 방식은 Swagger나 Actuator 엔드포인트에 대한 접근을 용이하게 하려는 의도였는데, 이런 예외 상황을 제대로 고려하지 못했네요.

**해결 방안**
처음에는 인증 정보가 없는 경우 `401(Unauthorized)` 응답을 강제로 설정하고, `shouldNotFilter` 메소드를 Override하여 Swagger나 Actuator 관련 엔드포인트들은 필터의 예외로 설정하여 해결하려고 했습니다. 하지만, 엔드포인트의 수가 많고, 추후 변경 가능성이 있어 이 방법은 선택하지 않았습니다.
결론적으로는 `@ExceptionHandler(AccessDeniedException.class)`를 추가하여 이 예외가 발생할 때 401 응답을 반환하도록 수정함으로써 해결했습니다.

---
Q:필터의 이점을 살린다면 내부에 들어오고 난 뒤에 예외를 추가하는 것 보다
처음에 토큰의 유무에따라 가능한 라우트에 해당하는지 여부를 검증하는 것이 더 낫지 않을까요?

A: 저도 이 부분 때문에 고민이 많이 들었어요. 사난님 말씀하신 방식이 필터의 이점도 살리고, 권한 여부판단을 화이트리스트 방식으로 관리하는 방안이라 보안에도 좋을 것 같다고 느꼈어요.
그런데 접근 가능한 엔드포인트들이 변경되거나 혹은 허용을 해줘야하는 엔드포인트를 놓친다거나 등등 고려해주어야 할 사안이 많다고 느꼈습니다. 추후에 버전업을 하거나 새로 허용해주어야 하는 엔드포인트가 추가된다거나 할 때마다 이 부분을 관리해줘야 하는 불편함이 있어서, 트레이드오프를 고려했을 때 유지보수의 용이성을 우선시하기로 결정했습니다.